### PR TITLE
docs(readme): clarify Vitess/MySQL vs Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build a products listing application with Golang and MySQL
 
-> **Note:** This demo targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This demo targets PlanetScale Vitess/MySQL. PlanetScale also offers managed Postgres. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This is an example demo showing how to integrate PlanetScale with Go to build a products listing application. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build a products listing application with Golang and MySQL
 
-> **Note:** This demo integrates PlanetScale Vitess/MySQL with Go—it is not the only way to use PlanetScale. PlanetScale also offers managed PostgreSQL. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This demo targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This is an example demo showing how to integrate PlanetScale with Go to build a products listing application. 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Build a products listing application with Golang and MySQL
 
+> **Note:** This demo integrates PlanetScale Vitess/MySQL with Go—it is not the only way to use PlanetScale. PlanetScale also offers managed PostgreSQL. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+
 This is an example demo showing how to integrate PlanetScale with Go to build a products listing application. 
 
 For the full tutorial and setup instructions, see the blog post: [Build a products listing application with Go and MySQL](https://planetscale.com/blog/build-products-listing-appliction-golang-mysql?utm_source=github&utm_medium=social&utm_campaign=blog_github_repos&utm_content=products_listing_go_mysql).


### PR DESCRIPTION
## Summary

- README: clarify that this repository targets PlanetScale Vitess/MySQL (or the MySQL tooling shown in the repo), not PlanetScale-only-MySQL.
- Link readers to Postgres documentation at https://planetscale.com/docs/postgres for managed PostgreSQL databases.

PlanetScale offers both MySQL-compatible (Vitess) and PostgreSQL products.

Made with [Cursor](https://cursor.com)